### PR TITLE
Add vehicle registration

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--format documentation

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -1,14 +1,23 @@
 class Facility
-  attr_reader :name, :address, :phone, :services
+  attr_reader :name,
+              :address,
+              :phone,
+              :services,
+              :registered_vehicles
 
   def initialize(details)
     @name = details[:name]
     @address = details[:address]
     @phone = details[:phone]
     @services = []
+    @registered_vehicles = []
   end
 
   def add_service(service)
     @services << service
+  end
+
+  def register_vehicle(vehicle)
+    @registered_vehicles << vehicle
   end
 end

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -5,7 +5,8 @@ class Facility
               :address,
               :phone,
               :services,
-              :registered_vehicles
+              :registered_vehicles,
+              :collected_fees
 
   def initialize(details)
     @name = details[:name]
@@ -13,6 +14,7 @@ class Facility
     @phone = details[:phone]
     @services = []
     @registered_vehicles = []
+    @collected_fees = 0
   end
 
   def add_service(service)
@@ -32,6 +34,16 @@ class Facility
       vehicle.plate_type = :ev
     else
       vehicle.plate_type = :regular
+    end
+  end
+
+  def collect_registration_fees(vehicle)
+    if vehicle.antique?
+      @collected_fees += 25
+    elsif vehicle.electric_vehicle?
+      @collected_fees += 200
+    else
+      @collected_fees += 100
     end
   end
 end

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -22,10 +22,12 @@ class Facility
   end
 
   def register_vehicle(vehicle)
-    @registered_vehicles << vehicle
-    vehicle.registration_date = Date.today
-    set_plate_type(vehicle)
-    collect_registration_fees(vehicle)
+    if @services.include?("Vehicle Registration")
+      @registered_vehicles << vehicle
+      vehicle.registration_date = Date.today
+      set_plate_type(vehicle)
+      collect_registration_fees(vehicle)
+    end
   end
 
   def set_plate_type(vehicle)

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -22,5 +22,16 @@ class Facility
   def register_vehicle(vehicle)
     @registered_vehicles << vehicle
     vehicle.registration_date = Date.today
+    set_plate_type(vehicle)
+  end
+
+  def set_plate_type(vehicle)
+    if vehicle.antique?
+      vehicle.plate_type = :antique
+    elsif vehicle.electric_vehicle?
+      vehicle.plate_type = :ev
+    else
+      vehicle.plate_type = :regular
+    end
   end
 end

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -25,6 +25,7 @@ class Facility
     @registered_vehicles << vehicle
     vehicle.registration_date = Date.today
     set_plate_type(vehicle)
+    collect_registration_fees(vehicle)
   end
 
   def set_plate_type(vehicle)

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 class Facility
   attr_reader :name,
               :address,
@@ -19,5 +21,6 @@ class Facility
 
   def register_vehicle(vehicle)
     @registered_vehicles << vehicle
+    vehicle.registration_date = Date.today
   end
 end

--- a/lib/vehicle.rb
+++ b/lib/vehicle.rb
@@ -1,12 +1,13 @@
 require 'date'
 
 class Vehicle
+  attr_accessor :registration_date
+
   attr_reader :vin,
               :year,
               :make,
               :model,
-              :engine,
-              :registration_date
+              :engine
 
   def initialize(vehicle_details)
     @vin = vehicle_details[:vin]

--- a/lib/vehicle.rb
+++ b/lib/vehicle.rb
@@ -1,7 +1,8 @@
 require 'date'
 
 class Vehicle
-  attr_accessor :registration_date
+  attr_accessor :registration_date,
+                :plate_type
 
   attr_reader :vin,
               :year,
@@ -15,6 +16,7 @@ class Vehicle
     @make = vehicle_details[:make]
     @model = vehicle_details[:model]
     @engine = vehicle_details[:engine]
+    @plate_type = nil
     @registration_date = nil
   end
 

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Facility do
       expect(@facility_1.registered_vehicles).to eq([@cruz])
     end
 
-    xit "sets the vehicles registration date during registration" do
+    it "sets the vehicles registration date during registration" do
       expect(@cruz.registration_date).to be nil
 
       @facility_1.register_vehicle(@cruz)

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -1,6 +1,4 @@
 require 'spec_helper'
-require './lib/facility'
-require './lib/vehicle'
 
 RSpec.describe Facility do
   before(:each) do
@@ -29,6 +27,50 @@ RSpec.describe Facility do
       @facility.add_service('Renew Drivers License')
       @facility.add_service('Vehicle Registration')
       expect(@facility.services).to eq(['New Drivers License', 'Renew Drivers License', 'Vehicle Registration'])
+    end
+  end
+
+  describe "#register_vehicle" do
+    it "can register a new vehicle" do
+      expect(@facility_1.registered_vehicles).to be_empty
+
+      @facility_1.register_vehicle(@cruz)
+
+      expect(@facility_1.registered_vehicles).to eq([@cruz])
+    end
+
+    it "sets the vehicles registration date during registration" do
+      expect(@cruz.registration_date).to be nil
+
+      @facility_1.register_vehicle(@cruz)
+
+      expect(@cruz.registration_date).to eq(Date.today)
+    end
+
+    it "sets the vehicles plate type during registration" do
+      expect(@cruz.plate_type).to be nil
+
+      @facility_1.register_vehicle(@cruz)
+
+      expect(@cruz.plate_type).to eq(:regular)
+    end
+
+    it "collects registration fees during registration" do
+      expect(@facility_1.collected_fees).to eq(0)
+
+      @facility_1.register_vehicle(@cruz)
+
+      expect(@facility_1.collected_fees).to eq(100)
+    end
+
+    it "can only register a vehicle if the facility offers registration service" do
+      expect(@facility_2.registered_vehicles).to be_empty
+      expect(@facility_2.services).to be_empty
+
+      @facility_2.register_vehicle(@bolt)
+
+      expect(@facility_2.registered_vehicles).to be_empty
+      expect(@facility_2.collected_fees).to eq(0)
     end
   end
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Facility do
       expect(@cruz.registration_date).to eq(Date.today)
     end
 
-    xit "sets the vehicles plate type during registration" do
+    it "sets the vehicles plate type during registration" do
       expect(@cruz.plate_type).to be nil
 
       @facility_1.register_vehicle(@cruz)
@@ -71,6 +71,22 @@ RSpec.describe Facility do
 
       expect(@facility_2.registered_vehicles).to be_empty
       expect(@facility_2.collected_fees).to eq(0)
+    end
+  end
+
+  describe "#set_plate_type" do
+    it "sets the plate type based on vehicle age and EV status" do
+      expect(@cruz.plate_type).to be nil
+      expect(@bolt.plate_type).to be nil
+      expect(@camaro.plate_type).to be nil
+
+      @facility_1.set_plate_type(@cruz)
+      @facility_1.set_plate_type(@bolt)
+      @facility_1.set_plate_type(@camaro)
+
+      expect(@cruz.plate_type).to eq(:regular)
+      expect(@bolt.plate_type).to eq(:ev)
+      expect(@camaro.plate_type).to eq(:antique)
     end
   end
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Facility do
       expect(@cruz.plate_type).to eq(:regular)
     end
 
-    xit "collects registration fees during registration" do
+    it "collects registration fees during registration" do
       expect(@facility_1.collected_fees).to eq(0)
 
       @facility_1.register_vehicle(@cruz)

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -89,4 +89,19 @@ RSpec.describe Facility do
       expect(@camaro.plate_type).to eq(:antique)
     end
   end
+
+  describe "#collect_registration_fees" do
+    it "collects a fee based on vehicle age and EV status" do
+      expect(@facility_1.collected_fees).to eq(0)
+
+      @facility_1.collect_registration_fees(@cruz)
+      expect(@facility_1.collected_fees).to eq(100)
+      
+      @facility_1.collect_registration_fees(@bolt)
+      expect(@facility_1.collected_fees).to eq(300)
+
+      @facility_1.collect_registration_fees(@camaro)
+      expect(@facility_1.collected_fees).to eq(325)
+    end
+  end
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -1,8 +1,16 @@
 require 'spec_helper'
+require './lib/facility'
+require './lib/vehicle'
 
 RSpec.describe Facility do
   before(:each) do
     @facility = Facility.new({name: 'DMV Tremont Branch', address: '2855 Tremont Place Suite 118 Denver CO 80205', phone: '(720) 865-4600'})
+    @facility_1 = Facility.new({name: 'DMV Tremont Branch', address: '2855 Tremont Place Suite 118 Denver CO 80205', phone: '(720) 865-4600'})
+    @facility_2 = Facility.new({name: 'DMV Northeast Branch', address: '4685 Peoria Street Suite 101 Denver CO 80239', phone: '(720) 865-4600'})
+    @cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice} )
+    @bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev} )
+    @camaro = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice} )
+    @facility_1.add_service('Vehicle Registration')
   end
   describe '#initialize' do
     it 'can initialize' do

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Facility do
       expect(@facility_1.collected_fees).to eq(100)
     end
 
-    xit "can only register a vehicle if the facility offers registration service" do
+    it "can only register a vehicle if the facility offers registration service" do
       expect(@facility_2.registered_vehicles).to be_empty
       expect(@facility_2.services).to be_empty
 

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Facility do
       expect(@facility_1.registered_vehicles).to eq([@cruz])
     end
 
-    it "sets the vehicles registration date during registration" do
+    xit "sets the vehicles registration date during registration" do
       expect(@cruz.registration_date).to be nil
 
       @facility_1.register_vehicle(@cruz)
@@ -47,7 +47,7 @@ RSpec.describe Facility do
       expect(@cruz.registration_date).to eq(Date.today)
     end
 
-    it "sets the vehicles plate type during registration" do
+    xit "sets the vehicles plate type during registration" do
       expect(@cruz.plate_type).to be nil
 
       @facility_1.register_vehicle(@cruz)
@@ -55,7 +55,7 @@ RSpec.describe Facility do
       expect(@cruz.plate_type).to eq(:regular)
     end
 
-    it "collects registration fees during registration" do
+    xit "collects registration fees during registration" do
       expect(@facility_1.collected_fees).to eq(0)
 
       @facility_1.register_vehicle(@cruz)
@@ -63,7 +63,7 @@ RSpec.describe Facility do
       expect(@facility_1.collected_fees).to eq(100)
     end
 
-    it "can only register a vehicle if the facility offers registration service" do
+    xit "can only register a vehicle if the facility offers registration service" do
       expect(@facility_2.registered_vehicles).to be_empty
       expect(@facility_2.services).to be_empty
 

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe Facility do
       @facility_1.register_vehicle(@cruz)
 
       expect(@facility_1.registered_vehicles).to eq([@cruz])
+
+      @facility_1.register_vehicle(@camaro)
+      @facility_1.register_vehicle(@bolt)
+
+      expect(@facility_1.registered_vehicles).to eq([@cruz, @camaro, @bolt])
     end
 
     it "sets the vehicles registration date during registration" do
@@ -49,18 +54,28 @@ RSpec.describe Facility do
 
     it "sets the vehicles plate type during registration" do
       expect(@cruz.plate_type).to be nil
+      expect(@camaro.plate_type).to be nil
 
       @facility_1.register_vehicle(@cruz)
+      @facility_1.register_vehicle(@camaro)
+      @facility_1.register_vehicle(@bolt)
 
       expect(@cruz.plate_type).to eq(:regular)
+      expect(@camaro.plate_type).to eq(:antique)
+      expect(@bolt.plate_type).to eq(:ev)
     end
 
     it "collects registration fees during registration" do
       expect(@facility_1.collected_fees).to eq(0)
 
       @facility_1.register_vehicle(@cruz)
-
+      
       expect(@facility_1.collected_fees).to eq(100)
+      
+      @facility_1.register_vehicle(@camaro)
+      @facility_1.register_vehicle(@bolt)
+      
+      expect(@facility_1.collected_fees).to eq(325)
     end
 
     it "can only register a vehicle if the facility offers registration service" do


### PR DESCRIPTION
Adds vehicle registration to the facility class. Registering a vehicle modifies:
- facility.registered_vehicles
- facility.collected_fees
- vehicle.registration_date
- vehicle.plate_type

Registration is only possible via facilities that have the "Vehicle Registration" service in their services[].