### PR TITLE
Ny lottery numbers

### DIFF
--- a/lib/lottery_data_service.rb
+++ b/lib/lottery_data_service.rb
@@ -1,0 +1,13 @@
+require 'faraday'
+require 'json'
+
+class LotteryDataService
+  def load_data(source)
+    response = Faraday.get(source)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def ny_lottery_data
+    @ny_lottery_data ||= load_data('https://data.ny.gov/resource/d6yy-54nr.json')
+  end
+end

--- a/lib/lottery_tracker.rb
+++ b/lib/lottery_tracker.rb
@@ -24,4 +24,13 @@ class LotteryTracker
       column_6: number_array.map { |winning_numbers| winning_numbers[5] }.sort.tally
     }
   end
+
+  def most_likely_number
+    most_likely_values = []
+    numbers_by_column = winning_numbers_by_column(get_all_numbers)
+    numbers_by_column.each do |column|
+      most_likely_values << column[1].max_by {|key, value| value}
+    end
+    most_likely_values.map {|value| value[0]}.join(" ")
+  end
 end

--- a/lib/lottery_tracker.rb
+++ b/lib/lottery_tracker.rb
@@ -26,12 +26,7 @@ class LotteryTracker
   end
 
   def most_likely_number
-    most_likely_values = []
-    numbers_by_column = winning_numbers_by_column(get_all_numbers)
-    numbers_by_column.each do |column|
-      most_likely_values << column[1].max_by {|key, value| value}
-    end
-    most_likely_values.map {|value| value[0]}.join(" ")
+    get_likely_pairs.map {|value| value[0]}.join(" ")
   end
 
   def most_likely_with_percent

--- a/lib/lottery_tracker.rb
+++ b/lib/lottery_tracker.rb
@@ -1,7 +1,16 @@
 class LotteryTracker
   attr_reader :dataset
-  
+
+  #get_all_numbers => array of arrays
+  #winning_numbers_by_column => hash of hashes
+  #most_likely_number => string
   def initialize(dataset)
     @dataset = dataset
+  end
+
+  def get_all_numbers
+    @dataset.map do |draw|
+      draw[:winning_numbers].split
+    end
   end
 end

--- a/lib/lottery_tracker.rb
+++ b/lib/lottery_tracker.rb
@@ -33,4 +33,8 @@ class LotteryTracker
     end
     most_likely_values.map {|value| value[0]}.join(" ")
   end
+
+  def most_likely_with_percent
+    
+  end
 end

--- a/lib/lottery_tracker.rb
+++ b/lib/lottery_tracker.rb
@@ -1,0 +1,3 @@
+class LotteryTracker
+  
+end

--- a/lib/lottery_tracker.rb
+++ b/lib/lottery_tracker.rb
@@ -13,4 +13,15 @@ class LotteryTracker
       draw[:winning_numbers].split
     end
   end
+
+  def winning_numbers_by_column(number_array)
+    numbers_by_column = {
+      column_1: number_array.map { |winning_numbers| winning_numbers[0] }.sort.tally,
+      column_2: number_array.map { |winning_numbers| winning_numbers[1] }.sort.tally,
+      column_3: number_array.map { |winning_numbers| winning_numbers[2] }.sort.tally,
+      column_4: number_array.map { |winning_numbers| winning_numbers[3] }.sort.tally,
+      column_5: number_array.map { |winning_numbers| winning_numbers[4] }.sort.tally,
+      column_6: number_array.map { |winning_numbers| winning_numbers[5] }.sort.tally
+    }
+  end
 end

--- a/lib/lottery_tracker.rb
+++ b/lib/lottery_tracker.rb
@@ -1,3 +1,7 @@
 class LotteryTracker
+  attr_reader :dataset
   
+  def initialize(dataset)
+    @dataset = dataset
+  end
 end

--- a/lib/lottery_tracker.rb
+++ b/lib/lottery_tracker.rb
@@ -1,9 +1,6 @@
 class LotteryTracker
   attr_reader :dataset
 
-  #get_all_numbers => array of arrays
-  #winning_numbers_by_column => hash of hashes
-  #most_likely_number => string
   def initialize(dataset)
     @dataset = dataset
   end
@@ -30,7 +27,10 @@ class LotteryTracker
   end
 
   def most_likely_with_percent
-
+    get_likely_pairs.map do |pair|
+      draw_percent = "#{(pair[1] / 10).to_f}%"
+      [pair[0], draw_percent]
+    end
   end
 
   def get_likely_pairs

--- a/lib/lottery_tracker.rb
+++ b/lib/lottery_tracker.rb
@@ -35,6 +35,15 @@ class LotteryTracker
   end
 
   def most_likely_with_percent
-    
+
+  end
+
+  def get_likely_pairs
+    most_likely_values = []
+    numbers_by_column = winning_numbers_by_column(get_all_numbers)
+    numbers_by_column.each do |column|
+      most_likely_values << column[1].max_by {|key, value| value}
+    end
+    most_likely_values
   end
 end

--- a/spec/lottery_data_service_spec.rb
+++ b/spec/lottery_data_service_spec.rb
@@ -1,0 +1,29 @@
+require './lib/lottery_data_service'
+
+RSpec.describe LotteryDataService do
+  describe "#initialize" do
+    it "exists" do
+      lds = LotteryDataService.new
+
+      expect(lds).to be_a LotteryDataService
+    end
+  end
+
+  describe "#load_data" do
+    it "can load data from a source" do
+      lds = LotteryDataService.new
+      source = "https://data.ny.gov/resource/d6yy-54nr.json"
+      data = lds.load_data(source)
+
+      expect(data).to be_an Array
+    end
+  end
+
+  describe "#ny_Lottery_data" do
+    it "can load ny lottery data" do
+      lds = LotteryDataService.new
+      require 'pry';binding.pry
+      expect(lds.ny_lottery_data).to be_an Array
+    end
+  end
+end

--- a/spec/lottery_tracker_spec.rb
+++ b/spec/lottery_tracker_spec.rb
@@ -4,9 +4,16 @@ require './lib/lottery_tracker'
 RSpec.describe LotteryTracker do
   describe "#initialize" do
     it "exists" do
-      tracker = LotteryTracker.new
+      tracker = LotteryTracker.new("placeholder")
 
       expect(tracker).to be_a LotteryTracker
+    end
+
+    it "has a dataset on initialize" do
+      tracker = LotteryTracker.new(LotteryDataService.new.ny_lottery_data)
+
+      expect(tracker.dataset).to be_an Array
+      expect(tracker.dataset).to_not be_empty
     end
   end
 end

--- a/spec/lottery_tracker_spec.rb
+++ b/spec/lottery_tracker_spec.rb
@@ -11,9 +11,19 @@ RSpec.describe LotteryTracker do
 
     it "has a dataset on initialize" do
       tracker = LotteryTracker.new(LotteryDataService.new.ny_lottery_data)
-
+      
       expect(tracker.dataset).to be_an Array
       expect(tracker.dataset).to_not be_empty
+    end
+  end
+  
+  describe "#get_all_numbers" do
+    it "returns an array of all winning numbers formatted in arrays" do
+      tracker = LotteryTracker.new(LotteryDataService.new.ny_lottery_data)
+      
+      expect(tracker.get_all_numbers).to be_an Array
+      expect(tracker.get_all_numbers.size).to be_an Integer
+      expect(tracker.get_all_numbers.first).to be_an Array
     end
   end
 end

--- a/spec/lottery_tracker_spec.rb
+++ b/spec/lottery_tracker_spec.rb
@@ -41,11 +41,27 @@ RSpec.describe LotteryTracker do
   describe "#most_likely_number" do
     it "returns a string of the most likely number based on recent drawings" do
       tracker = LotteryTracker.new(LotteryDataService.new.ny_lottery_data)
-      wins_by_column = tracker.winning_numbers_by_column(tracker.get_all_numbers)
-
+      
       expect(tracker.most_likely_number).to be_a String
       expect(tracker.most_likely_number.size).to eq(17)
       # require 'pry';binding.pry
+    end
+  end
+  
+  describe "#most_likely_with_percent" do
+    it "returns each most likely number per column with the percent of the time its drawn" do
+      tracker = LotteryTracker.new(LotteryDataService.new.ny_lottery_data)
+      
+      expect(tracker.most_likely_with_percent).to be_an Array
+      expect(tracker.most_likely_with_percent.first.size).to eq(2)
+    end
+  end
+  
+  describe "#get_likely_pairs" do
+    it "returns an array of each pair of likely numbers per column" do
+      tracker = LotteryTracker.new(LotteryDataService.new.ny_lottery_data)
+      
+      expect(tracker.get_likely_pairs).to be_an Array
     end
   end
 end

--- a/spec/lottery_tracker_spec.rb
+++ b/spec/lottery_tracker_spec.rb
@@ -1,0 +1,12 @@
+require './lib/lottery_data_service'
+require './lib/lottery_tracker'
+
+RSpec.describe LotteryTracker do
+  describe "#initialize" do
+    it "exists" do
+      tracker = LotteryTracker.new
+
+      expect(tracker).to be_a LotteryTracker
+    end
+  end
+end

--- a/spec/lottery_tracker_spec.rb
+++ b/spec/lottery_tracker_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe LotteryTracker do
   end
   
   describe "#most_likely_with_percent" do
-    xit "returns each most likely number per column with the percent of the time its drawn" do
+    it "returns each most likely number per column with the percent of the time its drawn" do
       tracker = LotteryTracker.new(LotteryDataService.new.ny_lottery_data)
       
       expect(tracker.most_likely_with_percent).to be_an Array

--- a/spec/lottery_tracker_spec.rb
+++ b/spec/lottery_tracker_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe LotteryTracker do
   end
   
   describe "#most_likely_with_percent" do
-    it "returns each most likely number per column with the percent of the time its drawn" do
+    xit "returns each most likely number per column with the percent of the time its drawn" do
       tracker = LotteryTracker.new(LotteryDataService.new.ny_lottery_data)
       
       expect(tracker.most_likely_with_percent).to be_an Array

--- a/spec/lottery_tracker_spec.rb
+++ b/spec/lottery_tracker_spec.rb
@@ -26,4 +26,16 @@ RSpec.describe LotteryTracker do
       expect(tracker.get_all_numbers.first).to be_an Array
     end
   end
+  
+  describe "#winning_numbers_by_column" do
+    it "returns a hash of each columns winning numbers tallied" do
+      tracker = LotteryTracker.new(LotteryDataService.new.ny_lottery_data)
+      wins_by_column = tracker.winning_numbers_by_column(tracker.get_all_numbers)
+
+      require 'pry';binding.pry
+      expect(wins_by_column).to be_a Hash
+      expect(wins_by_column.key?(:column_1)).to be true
+      expect(wins_by_column.size).to be(6)
+    end
+  end
 end

--- a/spec/lottery_tracker_spec.rb
+++ b/spec/lottery_tracker_spec.rb
@@ -31,11 +31,21 @@ RSpec.describe LotteryTracker do
     it "returns a hash of each columns winning numbers tallied" do
       tracker = LotteryTracker.new(LotteryDataService.new.ny_lottery_data)
       wins_by_column = tracker.winning_numbers_by_column(tracker.get_all_numbers)
-
-      require 'pry';binding.pry
+      
       expect(wins_by_column).to be_a Hash
       expect(wins_by_column.key?(:column_1)).to be true
       expect(wins_by_column.size).to be(6)
+    end
+  end
+  
+  describe "#most_likely_number" do
+    it "returns a string of the most likely number based on recent drawings" do
+      tracker = LotteryTracker.new(LotteryDataService.new.ny_lottery_data)
+      wins_by_column = tracker.winning_numbers_by_column(tracker.get_all_numbers)
+
+      expect(tracker.most_likely_number).to be_a String
+      expect(tracker.most_likely_number.size).to eq(17)
+      # require 'pry';binding.pry
     end
   end
 end


### PR DESCRIPTION
Adds a (FOR FUN ONLY) lottery tracker using NY's lottery API.

- #get_all_numbers: provides an array of each winning draw's numbers (each formatted as an array)
- #winning_numbers_by_columns: tallies each column's winning numbers and returns them as a hash of columns
- #most_likely_numbers: returns a string of the "most likely" to win number (based on the last 1000 draws, API limited)
- #most_likely_with_percent: returns an array of pairs. Each pair is the most frequent number for the column followed by its percent of draws over the last 1000 draws.
- #get_likely_pairs: helper method to find the most frequent number per column alongside the number of times it was drawn